### PR TITLE
Fix some issues and let HaplotypeCallerSpark be work.

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/HaplotypeCallerSpark.java
@@ -197,10 +197,10 @@ public final class HaplotypeCallerSpark extends AssemblyRegionWalkerSpark {
         final Path referencePath = IOUtils.getPath(referenceArguments.getReferenceFileName());
         final String referenceFileName = referencePath.getFileName().toString();
         final String pathOnExecutor = SparkFiles.get(referenceFileName);
-        final ReferenceSequenceFile taskReferenceSequenceFile = new CachingIndexedFastaSequenceFile(IOUtils.getPath(pathOnExecutor));
+        // final ReferenceSequenceFile taskReferenceSequenceFile = new CachingIndexedFastaSequenceFile(IOUtils.getPath(pathOnExecutor));
         final Collection<Annotation> annotations = makeVariantAnnotations();
         final VariantAnnotatorEngine annotatorEngine = new VariantAnnotatorEngine(annotations,  hcArgs.dbsnp.dbsnp, hcArgs.comps, hcArgs.emitReferenceConfidence != ReferenceConfidenceMode.NONE, false);
-        return assemblyRegionEvaluatorSupplierBroadcastFunction(ctx, hcArgs, assemblyRegionArgs, getHeaderForReads(), taskReferenceSequenceFile, annotatorEngine);
+        return assemblyRegionEvaluatorSupplierBroadcastFunction(ctx, hcArgs, assemblyRegionArgs, getHeaderForReads(), pathOnExecutor, annotatorEngine);
     }
 
     private static Broadcast<Supplier<AssemblyRegionEvaluator>> assemblyRegionEvaluatorSupplierBroadcast(
@@ -211,9 +211,9 @@ public final class HaplotypeCallerSpark extends AssemblyRegionWalkerSpark {
             final Collection<Annotation> annotations) {
         final Path referencePath = IOUtils.getPath(reference);
         final String referenceFileName = referencePath.getFileName().toString();
-        final ReferenceSequenceFile taskReferenceSequenceFile = taskReferenceSequenceFile(referenceFileName);
+        // final ReferenceSequenceFile taskReferenceSequenceFile = taskReferenceSequenceFile(referenceFileName);
         final VariantAnnotatorEngine annotatorEngine = new VariantAnnotatorEngine(annotations,  hcArgs.dbsnp.dbsnp, hcArgs.comps, hcArgs.emitReferenceConfidence != ReferenceConfidenceMode.NONE, false);
-        return assemblyRegionEvaluatorSupplierBroadcastFunction(ctx, hcArgs, assemblyRegionArgs, header, taskReferenceSequenceFile, annotatorEngine);
+        return assemblyRegionEvaluatorSupplierBroadcastFunction(ctx, hcArgs, assemblyRegionArgs, header, referenceFileName, annotatorEngine);
     }
 
     private static ReferenceSequenceFile taskReferenceSequenceFile(final String referenceFileName) {
@@ -225,7 +225,7 @@ public final class HaplotypeCallerSpark extends AssemblyRegionWalkerSpark {
             final JavaSparkContext ctx,
             final HaplotypeCallerArgumentCollection hcArgs,
             AssemblyRegionArgumentCollection assemblyRegionArgs, final SAMFileHeader header,
-            final ReferenceSequenceFile taskReferenceSequenceFile,
+            final String taskReferenceSequenceFile,
             final VariantAnnotatorEngine annotatorEngine) {
         Supplier<AssemblyRegionEvaluator> supplier = new Supplier<AssemblyRegionEvaluator>() {
             @Override

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -179,23 +179,7 @@ public final class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
     public HaplotypeCallerEngine(final HaplotypeCallerArgumentCollection hcArgs, AssemblyRegionArgumentCollection assemblyRegionArgs, boolean createBamOutIndex,
                                  boolean createBamOutMD5, final SAMFileHeader readsHeader,
                                  String referencePath, VariantAnnotatorEngine annotationEngine) {
-        this.hcArgs = Utils.nonNull(hcArgs);
-        this.readsHeader = Utils.nonNull(readsHeader);
-        this.referenceReader = Utils.nonNull(new CachingIndexedFastaSequenceFile(IOUtils.getPath(referencePath)));
-        this.annotationEngine = Utils.nonNull(annotationEngine);
-        this.aligner = SmithWatermanAligner.getAligner(hcArgs.smithWatermanImplementation);
-        trimmer = new AssemblyRegionTrimmer(assemblyRegionArgs, readsHeader.getSequenceDictionary());
-        forceCallingAllelesPresent = hcArgs.alleles != null;
-        initialize(createBamOutIndex, createBamOutMD5);
-        if (hcArgs.assemblyStateOutput != null) {
-            try {
-                assemblyDebugOutStream = new PrintStream(Files.newOutputStream(IOUtils.getPath(hcArgs.assemblyStateOutput)));
-            } catch (IOException e) {
-                throw new UserException.CouldNotCreateOutputFile(hcArgs.assemblyStateOutput, "Provided argument for assembly debug graph location could not be created");
-            }
-        } else {
-            assemblyDebugOutStream = null;
-        }
+        this(hcArgs, assemblyRegionArgs, createBamOutIndex, createBamOutMD5, readsHeader, new CachingIndexedFastaSequenceFile(IOUtils.getPath(referencePath)), annotationEngine);
     }
 
     /**

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/readthreading/ReadThreadingAssembler.java
@@ -78,7 +78,7 @@ public final class ReadThreadingAssembler {
                                   final int maxUnprunedVariants, final boolean useLinkedDebruijnGraphs) {
         Utils.validateArg( maxAllowedPathsForReadThreadingAssembler >= 1, "numBestHaplotypesPerGraph should be >= 1 but got " + maxAllowedPathsForReadThreadingAssembler);
         this.kmerSizes = new ArrayList<>(kmerSizes);
-        kmerSizes.sort(Integer::compareTo);
+        this.kmerSizes.sort(Integer::compareTo);
         this.dontIncreaseKmerSizesForCycles = dontIncreaseKmerSizesForCycles;
         this.allowNonUniqueKmersInRef = allowNonUniqueKmersInRef;
         this.numPruningSamples = numPruningSamples;


### PR DESCRIPTION
# Fixed Issues
- too many stack of reference file object serialization for `Kyro`.
- `kmerSizes` object sorting error.